### PR TITLE
Add link to hackernews comments

### DIFF
--- a/src/cards/HNCard.js
+++ b/src/cards/HNCard.js
@@ -31,7 +31,7 @@ const StoryItem = ({ item, index, analyticsTag }) => {
         <div className="rowDetails">
           <span className="rowItem hnRowItem" ><GoPrimitiveDot className="rowItemIcon" /> {item.score} points</span>
           <span className="rowItem" title={new Date(item.time * 1000).toUTCString()}><MdAccessTime className="rowItemIcon" /> {format(new Date(item.time * 1000))}</span>
-          <span className="rowItem"><BiCommentDetail className="rowItemIcon" /> {item.descendants} comments</span>
+          <a className="rowItem" href={`https://news.ycombinator.com/item?id=${item.id}`} target="_blank"><BiCommentDetail className="rowItemIcon" /> {item.descendants} comments</a>
         </div>
         </>
       )}


### PR DESCRIPTION
Thank you for developing this extension. I have used it and like it.
I often pick items I'm interested in on hackernews and often read their comments.
I have wanted to access hackernews comments pages from hackertab.
So I tried to change <span> tag for the count of hackernews comments to <a> tag to open hackernews pages.
What do you think of this idea? If you like it, please review and apply this patch.

Thanks again for creating this good extension.