### PR TITLE
feat: CardLink to HNCard comments

### DIFF
--- a/src/cards/HNCard.js
+++ b/src/cards/HNCard.js
@@ -1,66 +1,82 @@
-import React from 'react';
-import { format } from 'timeago.js';
-import { SiYcombinator } from 'react-icons/si';
-import { VscTriangleUp } from 'react-icons/vsc';
+import React from "react";
+import { format } from "timeago.js";
+import { SiYcombinator } from "react-icons/si";
+import { VscTriangleUp } from "react-icons/vsc";
 import CardComponent from "../components/CardComponent";
 import ListComponent from "../components/ListComponent";
-import hackernewsApi from '../services/hackernews'
-import { BiCommentDetail } from "react-icons/bi"
-import { MdAccessTime } from "react-icons/md"
-import { GoPrimitiveDot } from "react-icons/go"
+import hackernewsApi from "../services/hackernews";
+import { BiCommentDetail } from "react-icons/bi";
+import { MdAccessTime } from "react-icons/md";
+import { GoPrimitiveDot } from "react-icons/go";
 import CardLink from "../components/CardLink";
-import CardItemWithActions from '../components/CardItemWithActions'
-
+import CardItemWithActions from "../components/CardItemWithActions";
 
 const StoryItem = ({ item, index, analyticsTag }) => {
-
+  console.log(item);
   return (
     <CardItemWithActions
       source={"hackernews"}
       index={index}
       item={item}
       key={index}
-      cardItem={(
+      cardItem={
         <>
           <p className="rowTitle">
             <CardLink link={item.url} analyticsSource={analyticsTag}>
-            <VscTriangleUp className={"rowTitleIcon"} />
-            {item.title}
-          </CardLink>
-        </p>
-        <div className="rowDetails">
-          <span className="rowItem hnRowItem" ><GoPrimitiveDot className="rowItemIcon" /> {item.score} points</span>
-          <span className="rowItem" title={new Date(item.time * 1000).toUTCString()}><MdAccessTime className="rowItemIcon" /> {format(new Date(item.time * 1000))}</span>
-          <span className="rowItem"><BiCommentDetail className="rowItemIcon" /> {item.descendants} comments</span>
-        </div>
+              <VscTriangleUp className={"rowTitleIcon"} />
+              {item.title}
+            </CardLink>
+          </p>
+          <div className="rowDetails">
+            <span className="rowItem hnRowItem">
+              <GoPrimitiveDot className="rowItemIcon" /> {item.score} points
+            </span>
+            <span
+              className="rowItem"
+              title={new Date(item.time * 1000).toUTCString()}
+            >
+              <MdAccessTime className="rowItemIcon" />{" "}
+              {format(new Date(item.time * 1000))}
+            </span>
+            <CardLink
+              link={`https://news.ycombinator.com/item?id=${item.id}`}
+              analyticsSource={analyticsTag}
+              className="rowItem"
+            >
+              <BiCommentDetail className="rowItemIcon" /> {item.descendants}{" "}
+              comments
+            </CardLink>
+          </div>
         </>
-      )}
+      }
     />
-  )
-}
-
+  );
+};
 
 function HNCard({ analyticsTag, label }) {
-
   const fetchStories = async () => {
-    return await hackernewsApi.getTopStories()
-  }
+    return await hackernewsApi.getTopStories();
+  };
 
   const renderStories = (stories) => {
-    return stories.map((story, index) => <StoryItem item={story} key={`st-${index}`} index={index} analyticsTag={analyticsTag} />)
-  }
+    return stories.map((story, index) => (
+      <StoryItem
+        item={story}
+        key={`st-${index}`}
+        index={index}
+        analyticsTag={analyticsTag}
+      />
+    ));
+  };
 
   return (
     <CardComponent
-    icon={<SiYcombinator className="blockHeaderIcon" color="#FB6720" />}
+      icon={<SiYcombinator className="blockHeaderIcon" color="#FB6720" />}
       title={label}
-    > 
-      <ListComponent
-        fetchData={fetchStories}
-        renderData={renderStories}
-      />
+    >
+      <ListComponent fetchData={fetchStories} renderData={renderStories} />
     </CardComponent>
-  )
+  );
 }
 
-export default HNCard
+export default HNCard;


### PR DESCRIPTION
So first of all, thanks for this great extension / webapp! Big fan and daily user here! The one thing that was missing for me, that I want to do almost daily, is go to the HN page of the article, i.e. where the comments are. 

So I used your `CardLink` component to wrap the `X comments` text, linking to the `news.ycombinator.com/item?id=[item.id]`. Where `item.id` was already available in the component anyway. This just takes you to the HN comment page for each item.

You didn't ahve any prettier/standard/any sort of formatting settings in your repository, so my default prettier settings kinda went to town on this file. Sorry about that. You can just hit "save" once with your settings to "reset" it to your liking. The real changes are from L41-L45 basically