### PR TITLE
Fix: null check for hashnode post's date

### DIFF
--- a/src/features/cards/components/hashnodeCard/ArticleItem.tsx
+++ b/src/features/cards/components/hashnodeCard/ArticleItem.tsx
@@ -1,11 +1,11 @@
 import { BiCommentDetail } from 'react-icons/bi'
-import { CardLink, CardItemWithActions } from 'src/components/Elements'
+import { CardItemWithActions, CardLink } from 'src/components/Elements'
 
-import { BaseItemPropsType, Article } from 'src/types'
-import { format } from 'timeago.js'
 import { MdAccessTime } from 'react-icons/md'
 import { ColoredLanguagesBadge } from 'src/components/Elements'
 import { useUserPreferences } from 'src/stores/preferences'
+import { Article, BaseItemPropsType } from 'src/types'
+import { format } from 'timeago.js'
 
 import { AiTwotoneHeart } from 'react-icons/ai'
 import { Attributes } from 'src/lib/analytics'
@@ -40,14 +40,15 @@ const ArticleItem = (props: BaseItemPropsType<Article>) => {
             )}
             <div className="subTitle">{item.title}</div>
           </CardLink>
-
           {listingMode === 'normal' && (
             <>
               <p className="rowDescription">
-                <span className="rowItem">
-                  <MdAccessTime className={'rowTitleIcon'} />
-                  {format(new Date(item.published_at))}
-                </span>
+                {(item.published_at!==null && item.published_at !== undefined) && (
+                  <span className="rowItem">
+                    <MdAccessTime className={'rowTitleIcon'} />
+                    {format(new Date(item.published_at))}
+                  </span>
+                )}
                 <span className="rowItem">
                   <BiCommentDetail className={'rowTitleIcon'} />
                   {item.comments || 0} comments

--- a/src/features/cards/components/hashnodeCard/ArticleItem.tsx
+++ b/src/features/cards/components/hashnodeCard/ArticleItem.tsx
@@ -43,7 +43,7 @@ const ArticleItem = (props: BaseItemPropsType<Article>) => {
           {listingMode === 'normal' && (
             <>
               <p className="rowDescription">
-                {(item.published_at!==null && item.published_at !== undefined) && (
+                {item.published_at && (
                   <span className="rowItem">
                     <MdAccessTime className={'rowTitleIcon'} />
                     {format(new Date(item.published_at))}


### PR DESCRIPTION
# Pull Request Description

This pull request addresses a bug where Hashnode's posts were displaying an incorrect publish date.

Fixes #159

# Cause of the Bug
The bug was caused by receiving a `null` value for the `published_at` attribute. When attempting to construct a new date using `null`, it resulted in a date like this: Thu Jan 01 1970 05:30:00 GMT+0530 (India Standard Time).

![Bug Screenshot](https://github.com/medyo/hackertab.dev/assets/99007146/1799bab7-2f38-451a-addd-86bdcd952f7e)
![Bug Screenshot](https://github.com/medyo/hackertab.dev/assets/99007146/853fefab-a2c6-4c18-b54c-bf5116d0ed95)

# Fix
I have applied a null check to ensure that the `published_at` attribute is not null before rendering it in the span.

![Fix Screenshot](https://github.com/medyo/hackertab.dev/assets/99007146/ea46b251-aa84-48ff-a288-44fcd9b7219e)
