### PR TITLE
fix: Handle zeroes for stars_in_range and forks_count in github card

### DIFF
--- a/src/features/cards/components/githubCard/RepoItem.tsx
+++ b/src/features/cards/components/githubCard/RepoItem.tsx
@@ -51,7 +51,7 @@ const RepoItem = ({
                   <VscStarFull className="rowItemIcon" /> {numberWithCommas(item.stars_count)} stars
                 </span>
               )}
-              {item.stars_in_range && (
+              {item.stars_in_range !== undefined && (
                 <span className="rowItem">
                   <VscStarFull className="rowItemIcon" />{' '}
                   {numberWithCommas(item.stars_in_range || 0)} stars{' '}
@@ -60,7 +60,7 @@ const RepoItem = ({
                     : 'today'}
                 </span>
               )}
-              {item.forks_count && (
+              {item.forks_count !== undefined && (
                 <span className="rowItem">
                   <VscRepoForked className="rowItemIcon" /> {numberWithCommas(item.forks_count)}{' '}
                   forks


### PR DESCRIPTION
Hi!

I've just started using hackertab as my homepage, and I noticed that on the github cards there appears a zero that clashes a lot with everything and seems unintentional, see below.

<img width="329" height="433" alt="image" src="https://github.com/user-attachments/assets/2bf31542-8852-4ec5-ae0e-59fdf1bc5453" />

Unfortunately I couldn't test locally as I don't have access to the hackertab backend and don't know how to set it up locally. If you have any instructions, I'd love to add it to the README and test it myself.