### PR TITLE
Add dark mode styling for githubTitle

### DIFF
--- a/src/assets/App.css
+++ b/src/assets/App.css
@@ -574,6 +574,10 @@ a {
   color: #0366d6;
 }
 
+.dark .githubTitle {
+  color: #79c0ff;
+}
+
 .rowDescription {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
Makes the titles more readable when using dark mode